### PR TITLE
Made compilable with modern compilers

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([crudeoauth], [1.0.0], [packages@univention.de])
+AC_INIT([crudeoauth],[1.0.0],[packages@univention.de])
 AC_CONFIG_SRCDIR([oauthbearer.c])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
@@ -9,7 +9,7 @@ AM_INIT_AUTOMAKE([foreign])
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_INSTALL
-AC_PROG_LIBTOOL
+LT_INIT
 
 AC_ARG_WITH(pkg-config, AS_HELP_STRING([--with-pkg-config=PATH], [set pkg-config metadata search path.]),
             PKG_CONFIG_PATH="${withval}", PKG_CONFIG_PATH="")

--- a/src/oauthbearer.c
+++ b/src/oauthbearer.c
@@ -61,10 +61,10 @@
   }
 #define AUTOPTR(type) \
   __attribute__((cleanup(AUTOPTR_FUNC_NAME(type)))) type *
-DEFINE_AUTOPTR_FUNC(char, r_free);
-DEFINE_AUTOPTR_FUNC(jwks_t, r_jwks_free);
-DEFINE_AUTOPTR_FUNC(jwk_t, r_jwk_free);
-DEFINE_AUTOPTR_FUNC(jwt_t, r_jwt_free);
+DEFINE_AUTOPTR_FUNC(char, r_free)
+DEFINE_AUTOPTR_FUNC(jwks_t, r_jwks_free)
+DEFINE_AUTOPTR_FUNC(jwk_t, r_jwk_free)
+DEFINE_AUTOPTR_FUNC(jwt_t, r_jwt_free)
 
 
 #ifdef HACK
@@ -220,6 +220,7 @@ enum OAuthError oauth_check_required_scopes(
 	const void *utils,
 	jwt_t *jwt
 ) {
+	UNUSED(utils);
 	struct oauth_list *scope;
 
 	SLIST_FOREACH(scope, &ctx->glob_context->required_scope, next) {
@@ -312,7 +313,7 @@ jwks_t * oauth_get_jwks(
 		goto out;
 	}
 
-	for (int i=0; i<r_jwks_size(jwks); i++) {
+	for (size_t i=0; i<r_jwks_size(jwks); i++) {
 		jwk_t *jwk = r_jwks_get_at(jwks, i);
 		if(r_jwk_is_valid(jwk) != RHN_OK) {
 			oauth_error(utils, 0, "Error: JWK is not valid");

--- a/src/oauthbearer.h
+++ b/src/oauthbearer.h
@@ -34,6 +34,10 @@
 #define MAYBE_COMPRESS 1
 #define JWT_MINLEN 76 /* len(b64encode(b'{"access_token":"eyJhbGciOiJub25lIn0.eyJzdWIiOiJ7fX0.."}')) */
 
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
+
 enum OAuthError {
 	OK,
 	CLAIM_EXPIRED,

--- a/src/pam_oauthbearer.c
+++ b/src/pam_oauthbearer.c
@@ -59,6 +59,8 @@ void oauth_log(
 	const char *fmt,
 	...
 ) {
+	UNUSED(utils);
+
 	va_list ap;
 
 	va_start(ap, fmt);
@@ -72,6 +74,8 @@ void oauth_error(
 	const char *fmt,
 	...
 ) {
+	UNUSED(utils);
+
 	va_list ap;
 
 	if (pri == 0)
@@ -88,6 +92,8 @@ int oauth_strdup(
 	char **dst,
 	int *len
 ) {
+	UNUSED(utils);
+
 	*dst = strdup(src);
 	if (*dst == NULL)
 		return -1;
@@ -124,6 +130,9 @@ static void gctx_cleanup(
 	void *data,
 	int error
 ) {
+	UNUSED(pamh);
+	UNUSED(error);
+
 	oauth_glob_context_t *gctx = (oauth_glob_context_t *)data;
 
 	if (gctx != NULL) {
@@ -174,7 +183,7 @@ static oauth_glob_context_t * pam_global_context_init(
 	int ac,
 	const char **av
 ) {
-	int error;
+	int error = 0;
 	const void *data;
 	oauth_glob_context_t *gctx;
 	int i;
@@ -396,6 +405,8 @@ PAM_EXTERN int pam_sm_authenticate(
 	int ac,
 	const char **av
 ) {
+	UNUSED(flags);
+
 	oauth_serv_context_t ctx;
 	struct passwd *pwd;
 	struct passwd pwres;
@@ -538,6 +549,10 @@ PAM_EXTERN int pam_sm_setcred(
 	int ac,
 	const char **av
 ) {
+	UNUSED(pamh);
+	UNUSED(flags);
+	UNUSED(ac);
+	UNUSED(av);
 	return PAM_SUCCESS;
 }
 
@@ -548,6 +563,10 @@ PAM_EXTERN int pam_sm_acct_mgmt(
 	int ac,
 	const char **av
 ) {
+	UNUSED(pamh);
+	UNUSED(flags);
+	UNUSED(ac);
+	UNUSED(av);
 	return PAM_SUCCESS;
 }
 
@@ -558,6 +577,10 @@ PAM_EXTERN int pam_sm_open_session(
 	int ac,
 	const char **av
 ) {
+	UNUSED(pamh);
+	UNUSED(flags);
+	UNUSED(ac);
+	UNUSED(av);
 	return PAM_SUCCESS;
 }
 
@@ -567,6 +590,10 @@ PAM_EXTERN int pam_sm_close_session(
 	int ac,
 	const char **av
 ) {
+	UNUSED(pamh);
+	UNUSED(flags);
+	UNUSED(ac);
+	UNUSED(av);
 	return PAM_SUCCESS;
 }
 
@@ -576,6 +603,10 @@ PAM_EXTERN int pam_sm_chauthtok(
 	int ac,
 	const char **av
 ) {
+	UNUSED(pamh);
+	UNUSED(flags);
+	UNUSED(ac);
+	UNUSED(av);
 	return PAM_SUCCESS;
 }
 

--- a/src/plugin_common.c
+++ b/src/plugin_common.c
@@ -66,6 +66,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>

--- a/src/sasl_oauthbearer.c
+++ b/src/sasl_oauthbearer.c
@@ -105,6 +105,8 @@ void oauth_error(
 	const char *fmt,
 	...
 ) {
+	UNUSED(pri);
+
 	sasl_utils_t *sasl_utils;
 	char msg[4096];
 	va_list ap;
@@ -248,6 +250,8 @@ static int encode_saslname(
 char * oauthbearer_error_as_json(
 	enum OAuthError code
 ) {
+	UNUSED(code);
+
 	/* RFC 7628: 3.2.2 Server Response to Failed Authentication
 
 	status (REQUIRED)
@@ -270,6 +274,9 @@ static int oauth_server_mech_new(
 	unsigned int challen,
 	void **conn_context
 ) {
+	UNUSED(challen);
+	UNUSED(challenge);
+
 	oauth_serv_context_t *ctx;
 
 	if (conn_context == NULL) {
@@ -532,6 +539,8 @@ static void oauth_server_mech_free(
 	void *glob_context,
 	const sasl_utils_t *utils
 ) {
+	UNUSED(utils);
+
 	struct oauth_list *item;
 	oauth_glob_context_t *gctx;
 
@@ -608,6 +617,8 @@ int sasl_server_plug_init(
 	char propname[1024];
 	int propnum = 0;
 	FILE *jwks_fp;
+
+	UNUSED(jwks_fp);
 
 	if (maxvers < SASL_SERVER_PLUG_VERSION) {
 		utils->log(NULL, SASL_LOG_ERR, "OAUTHBEARER version mismatch");
@@ -854,6 +865,8 @@ static int oauth_client_mech_new(
 	sasl_client_params_t *params,
 	void **conn_context
 ) {
+	UNUSED(glob_context);
+
 	oauth_client_context *text;
 
 	if ((text = params->utils->malloc(sizeof(*text))) == NULL) {


### PR DESCRIPTION
This is what I use to get it to compile on COPR for distros using recent versions of GCC/autotools. It might be useful for it to be able to compile on newer systems until the rewrite in Rust is done.